### PR TITLE
Not everything's a boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,24 @@ end
 `context` takes a Symbol-keyed Hash of additional information to publish and
 merges it with the default payload.
 
+#### Transforming results
+
+If the result of science is more verbose than you need, you can use a transform
+operation to publish only the research you need. The transformation will
+also be used for comparing results. The non-transformed control result will
+still be returned.
+
+If the transformation raises an exception, the non-transformed result will be
+compared and published.
+
+```ruby
+science "widget-loading" do |e|
+  e.control   { Widget.scope.scope.all }
+  e.candidate { Widget.new_scope.all }
+  e.transform { |result| result.map(&:id).sort }
+end
+```
+
 ## Hacking on science
 
 Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs

--- a/README.md
+++ b/README.md
@@ -179,3 +179,7 @@ Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs
 the unit tests. All development dependencies will be installed automatically if
 they're not available. Dat science happens primarily on Ruby 1.9.3 and 1.8.7,
 but science should be universal.
+
+## Maintainers
+
+[@jbarnette](https://github.com/jbarnette) and [@rick](https://github.com/rick)

--- a/lib/dat/science/experiment.rb
+++ b/lib/dat/science/experiment.rb
@@ -41,6 +41,13 @@ module Dat
         @control
       end
 
+      # Public: Declare transform behavior on results for comparison
+      # returns `block`
+      def transform(&block)
+        @transform = block if block
+        @transform
+      end
+
       # Public: Run the control and candidate behaviors, timing each and
       # comparing the results. The run order is randomized. Returns the control
       # behavior's result.
@@ -72,7 +79,7 @@ module Dat
 
         raise control.exception if control.raised?
 
-        control.value
+        control.original_value
       end
 
       protected
@@ -80,6 +87,11 @@ module Dat
       # Internal: Does this experiment have candidate behavior?
       def candidate?
         !!candidate
+      end
+
+      # Internal: Did we get a custom transform?
+      def transform?
+        !!transform
       end
 
       # Internal: Should the control behavior run first?
@@ -107,7 +119,7 @@ module Dat
         end
 
         duration = (Time.now - start) * 1000
-        Science::Result.new value, duration, raised
+        Science::Result.new value, duration, raised, transform
       end
 
 

--- a/lib/dat/science/result.rb
+++ b/lib/dat/science/result.rb
@@ -5,12 +5,14 @@ module Dat
     class Result
       attr_reader :duration
       attr_reader :exception
-      attr_reader :value
+      attr_reader :transform
+      attr_reader :original_value
 
-      def initialize(value, duration, exception)
-        @duration  = duration
-        @exception = exception
-        @value     = value
+      def initialize(value, duration, exception, transform = nil)
+        @duration       = duration
+        @exception      = exception
+        @original_value = value
+        @transform      = transform
       end
 
       def ==(other)
@@ -38,6 +40,21 @@ module Dat
 
       def raised?
         !!exception
+      end
+
+      def value
+        @transformed_value = transformed unless defined?(@transformed_value)
+        @transformed_value
+      end
+
+      def transformed
+        return @original_value unless transform
+
+        begin
+          return transform.call @original_value
+        rescue
+          @original_value
+        end
       end
     end
   end


### PR DESCRIPTION
The first thing I tried to use this on was loading a list of widgets, and the results on failures were absolutely massive. I was shaving it down in the publisher, but it felt weird to write experiment-specific stuff in the results handler. So now you can do:

``` ruby
science "widget-loading" do |e|
  e.control   { Widget.scope.scope.all }
  e.candidate { Widget.new_scope.all }
  e.transform { |result| result.map(&:id).sort }
end
```

The comparison and publish both happen on the transformed version.

I also think there might be a use for custom comparison functions (floats or unordered comparison, for example) but it's a little less clear how to tack that on to `Result`.
