### PR TITLE
Put exceptions on the wire as a hash

### DIFF
--- a/lib/dat/science/result.rb
+++ b/lib/dat/science/result.rb
@@ -37,9 +37,14 @@ module Dat
       def payload
         {
           :duration  => duration,
-          :exception => exception,
+          :exception => serialize_exception(exception),
           :value     => experiment.clean(value)
         }
+      end
+
+      def serialize_exception(exception)
+        return nil unless exception
+        { :class => exception.class.name, :message => exception.message }
       end
 
       def raised?

--- a/lib/dat/science/result.rb
+++ b/lib/dat/science/result.rb
@@ -37,12 +37,12 @@ module Dat
       def payload
         {
           :duration  => duration,
-          :exception => serialize_exception(exception),
+          :exception => serialized_exception,
           :value     => experiment.clean(value)
         }
       end
 
-      def serialize_exception(exception)
+      def serialized_exception
         return nil unless exception
         { :class => exception.class.name, :message => exception.message }
       end

--- a/lib/dat/science/result.rb
+++ b/lib/dat/science/result.rb
@@ -44,7 +44,11 @@ module Dat
 
       def serialized_exception
         return nil unless exception
-        { :class => exception.class.name, :message => exception.message }
+        {
+          :class     => exception.class.name,
+          :message   => exception.message,
+          :backtrace => exception.backtrace
+        }
       end
 
       def raised?

--- a/test/dat_science_experiment_test.rb
+++ b/test/dat_science_experiment_test.rb
@@ -257,4 +257,22 @@ class DatScienceExperimentTest < MiniTest::Unit::TestCase
     refute_nil payload[:control][:exception]
     refute_nil payload[:candidate][:exception]
   end
+
+  def test_publishes_exception_data
+    e = Experiment.new "foo"
+    e.control { raise "foo" }
+    e.candidate { raise "bar" }
+
+    assert_raises RuntimeError do
+      e.run
+    end
+
+    event, payload = Experiment.published.first
+    refute_nil event
+    refute_nil payload
+
+    assert_equal :mismatch, event
+    assert_equal({ :message => 'foo', :class => 'RuntimeError' }, payload[:control][:exception])
+    assert_equal({ :message => 'bar', :class => 'RuntimeError' }, payload[:candidate][:exception])
+  end
 end

--- a/test/dat_science_experiment_test.rb
+++ b/test/dat_science_experiment_test.rb
@@ -272,7 +272,11 @@ class DatScienceExperimentTest < MiniTest::Unit::TestCase
     refute_nil payload
 
     assert_equal :mismatch, event
-    assert_equal({ :message => 'foo', :class => 'RuntimeError' }, payload[:control][:exception])
-    assert_equal({ :message => 'bar', :class => 'RuntimeError' }, payload[:candidate][:exception])
+    assert_equal 'foo',          payload[:control][:exception][:message]
+    assert_equal 'RuntimeError', payload[:control][:exception][:class]
+    refute_nil                   payload[:control][:exception][:backtrace]
+    assert_equal 'bar',          payload[:candidate][:exception][:message]
+    assert_equal 'RuntimeError', payload[:candidate][:exception][:class]
+    refute_nil                   payload[:candidate][:exception][:backtrace]
   end
 end


### PR DESCRIPTION
This should address issues we were seeing with published exceptions not having any real data.

/cc @josh @jbarnette 
