### PR TITLE
Update deps

### DIFF
--- a/dat-science.gemspec
+++ b/dat-science.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep /^test/
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency "minitest"
-  gem.add_development_dependency "mocha"
+  gem.add_development_dependency "minitest", "~> 5.0.8"
+  gem.add_development_dependency "mocha",    "~> 0.14.0"
 end

--- a/test/dat_science_experiment_test.rb
+++ b/test/dat_science_experiment_test.rb
@@ -1,7 +1,7 @@
 require "minitest/autorun"
 require "dat/science/experiment"
 
-class DatScienceExperimentTest < MiniTest::Unit::TestCase
+class DatScienceExperimentTest < MiniTest::Test
   class Experiment < Dat::Science::Experiment
     def self.published
       @published ||= []

--- a/test/dat_science_test.rb
+++ b/test/dat_science_test.rb
@@ -2,7 +2,7 @@ require "minitest/autorun"
 require "mocha/setup"
 require "dat/science"
 
-class DatScienceTest < MiniTest::Unit::TestCase
+class DatScienceTest < MiniTest::Test
   def teardown
     Dat::Science.reset
   end


### PR DESCRIPTION
Pin minitest and mocha, stop using the deprecated MiniTest::Unit::TestCase constant.
