### PR TITLE
Make comparator block argument ordering explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ science "loose-comparison" do |e|
 end
 ```
 
+The arguments yielded to the comparator block are the control value followed by
+the candidate value.
+
 ### Ramping up experiments
 
 By default the `candidate` block of an experiment will run 100% of the time.

--- a/lib/dat/science/result.rb
+++ b/lib/dat/science/result.rb
@@ -18,7 +18,7 @@ module Dat
       def ==(other)
         return false unless other.is_a? Dat::Science::Result
 
-        values_are_equal = experiment.compare(other.value, value)
+        values_are_equal = experiment.compare(value, other.value)
         both_raised      = other.raised? && raised?
         neither_raised   = !other.raised? && !raised?
 

--- a/test/dat_science_experiment_test.rb
+++ b/test/dat_science_experiment_test.rb
@@ -71,6 +71,19 @@ class DatScienceExperimentTest < MiniTest::Test
     assert_equal :mismatch, event
   end
 
+  def test_comparator_order
+    yielded = nil
+    e = Experiment.new "foo"
+    e.control { "control" }
+    e.candidate { "candidate" }
+    e.comparator do |a, b|
+      yielded = [a, b]
+    end
+    e.run
+
+    assert_equal ["control", "candidate"], yielded
+  end
+
   def test_context_default
     e = Experiment.new "foo"
 


### PR DESCRIPTION
When writing a complex experiment, it's helpful to know in what order the values are yielded to the comparator block. This fixes and documents the ordering: `comparator { |control_value, candidate_value| ... }`.
