### PR TITLE
Extract Experiment#evaluate(control, candidate)

### DIFF
--- a/lib/dat/science/experiment.rb
+++ b/lib/dat/science/experiment.rb
@@ -101,12 +101,23 @@ module Dat
           :first     => control_runs_first? ? :control : :candidate
         }
 
-        kind = control == candidate ? :match : :mismatch
+        kind = evaluate control, candidate
         publish_with_context kind, payload
 
         raise control.exception if control.raised?
 
         control.value
+      end
+
+      # Public: Determine the outcome of an experiment run
+      #
+      # control - result from running control method
+      # candidate - result from running candidate method
+      #
+      # Returns :match if control and candidate produced the same
+      # result, :mismatch otherwise.
+      def evaluate(control, candidate)
+        control == candidate ? :match : :mismatch
       end
 
       protected


### PR DESCRIPTION
This allows for subclasses of Dat::Science to change the behavior
of determining if a run produced a match or a mismatch (or to add
additional types of results here).

/cc @jbarnette 
